### PR TITLE
add limit channeling based on altar level

### DIFF
--- a/contracts/InstallationDiamond/facets/InstallationAdminFacet.sol
+++ b/contracts/InstallationDiamond/facets/InstallationAdminFacet.sol
@@ -8,7 +8,7 @@ import {RealmDiamond} from "../../interfaces/RealmDiamond.sol";
 import "hardhat/console.sol";
 
 contract InstallationAdminFacet is Modifiers {
-  event AddressesUpdated(address _aavegotchiDiamond, address _realmDiamond, address _glmr);
+  event AddressesUpdated(address _aavegotchiDiamond, address _realmDiamond, address _glmr, address _pixelCraft, address _aavegotchiDAO);
 
   /// @notice Allow the Diamond owner to deprecate an installation
   /// @dev Deprecated installations cannot be crafted by users
@@ -26,12 +26,16 @@ contract InstallationAdminFacet is Modifiers {
   function setAddresses(
     address _aavegotchiDiamond,
     address _realmDiamond,
-    address _glmr
+    address _glmr,
+    address _pixelCraft,
+    address _aavegotchiDAO
   ) external onlyOwner {
     s.aavegotchiDiamond = _aavegotchiDiamond;
     s.realmDiamond = _realmDiamond;
     s.glmr = _glmr;
-    emit AddressesUpdated(_aavegotchiDiamond, _realmDiamond, _glmr);
+    s.pixelCraft = _pixelCraft;
+    s.aavegotchiDAO = _aavegotchiDAO;
+    emit AddressesUpdated(_aavegotchiDiamond, _realmDiamond, _glmr, _pixelCraft, _aavegotchiDAO);
   }
 
   /// @notice Allow the diamond owner to add an installation type

--- a/contracts/InstallationDiamond/facets/InstallationFacet.sol
+++ b/contracts/InstallationDiamond/facets/InstallationFacet.sol
@@ -203,6 +203,11 @@ contract InstallationFacet is Modifiers {
     }
   }
 
+  function getAltarLevel(uint256 _altarId) external view returns (uint256 altarLevel_) {
+    require(_altarId < s.installationTypes.length, "InstallationFacet: Item type doesn't exist");
+    altarLevel_ = s.installationTypes[_altarId].level;
+  }
+
   /***********************************|
    |             Write Functions        |
    |__________________________________*/

--- a/contracts/InstallationDiamond/facets/InstallationFacet.sol
+++ b/contracts/InstallationDiamond/facets/InstallationFacet.sol
@@ -7,6 +7,7 @@ import {LibStrings} from "../../libraries/LibStrings.sol";
 import {LibERC1155} from "../../libraries/LibERC1155.sol";
 import {LibERC20} from "../../libraries/LibERC20.sol";
 import {LibInstallation} from "../../libraries/LibInstallation.sol";
+import {LibItems} from "../../libraries/LibItems.sol";
 import {IERC721} from "../../interfaces/IERC721.sol";
 import {RealmDiamond} from "../../interfaces/RealmDiamond.sol";
 import {IERC20} from "../../interfaces/IERC20.sol";
@@ -230,7 +231,7 @@ contract InstallationFacet is Modifiers {
       require(!installationType.deprecated, "InstallationFacet: Installation has been deprecated");
 
       //take the required alchemica
-      LibInstallation._splitAlchemica(installationType.alchemicaCost, alchemicaAddresses);
+      LibItems._splitAlchemica(installationType.alchemicaCost, alchemicaAddresses);
 
       if (installationType.craftTime == 0) {
         LibERC1155._safeMint(msg.sender, _installationTypes[i], 0);
@@ -383,7 +384,7 @@ contract InstallationFacet is Modifiers {
     //take the required alchemica
     address[4] memory alchemicaAddresses = realm.getAlchemicaAddresses();
     InstallationType memory installationType = s.installationTypes[_upgradeQueue.installationId];
-    LibInstallation._splitAlchemica(installationType.alchemicaCost, alchemicaAddresses);
+    LibItems._splitAlchemica(installationType.alchemicaCost, alchemicaAddresses);
 
     //current installation
     InstallationType memory prevInstallation = s.installationTypes[_upgradeQueue.installationId];

--- a/contracts/RealmDiamond/facets/AlchemicaFacet.sol
+++ b/contracts/RealmDiamond/facets/AlchemicaFacet.sol
@@ -305,7 +305,13 @@ contract AlchemicaFacet is Modifiers {
   ) external onlyParcelOwner(_realmId) onlyGotchiOwner(_gotchiId) {
     require(_lastChanneled == s.gotchiChannelings[_gotchiId], "AlchemicaFacet: Incorrect last duration");
 
-    require(block.timestamp - _lastChanneled >= 1 days, "AlchemicaFacet: Can't channel yet");
+    require(block.timestamp - _lastChanneled >= 1 days, "AlchemicaFacet: Gotchi can't channel yet");
+
+    InstallationDiamondInterface.InstallationType memory altar = InstallationDiamondInterface(s.installationsDiamond).getInstallationType(
+      s.parcels[_realmId].altarId
+    );
+
+    require(block.timestamp > s.parcelChannelings[_realmId] + s.channelingLimits[altar.level], "AlchemicaFacet: Parcel can't channel yet");
 
     //Use _lastChanneled to ensure that each signature hash is unique
     require(
@@ -336,6 +342,7 @@ contract AlchemicaFacet is Modifiers {
 
     //update latest channeling
     s.gotchiChannelings[_gotchiId] = block.timestamp;
+    s.parcelChannelings[_realmId] = block.timestamp;
 
     emit ChannelAlchemica(_realmId, _gotchiId, channelAmounts, rate, radius);
   }
@@ -377,7 +384,7 @@ contract AlchemicaFacet is Modifiers {
 
   /// @notice Helper function to batch transfer alchemica
   /// @param _targets Array of target addresses
-  /// @param _amounts Nested array of amounts to transfer. 
+  /// @param _amounts Nested array of amounts to transfer.
   /// @dev The inner array element order for _amounts is FUD, FOMO, ALPHA, KEK
   function batchTransferAlchemica(address[] calldata _targets, uint256[4][] calldata _amounts) external {
     require(_targets.length == _amounts.length, "AlchemicaFacet: Mismatched array lengths");
@@ -389,12 +396,19 @@ contract AlchemicaFacet is Modifiers {
       AlchemicaToken(s.alchemicaAddresses[3])
     ];
 
-    for(uint i = 0; i < _targets.length; i++) {
-      for(uint j = 0; j < _amounts[i].length; j++) {
-        if(_amounts[i][j] > 0) {
+    for (uint256 i = 0; i < _targets.length; i++) {
+      for (uint256 j = 0; j < _amounts[i].length; j++) {
+        if (_amounts[i][j] > 0) {
           alchemicas[j].transferFrom(msg.sender, _targets[i], _amounts[i][j]);
         }
       }
+    }
+  }
+
+  function setChannelingLimits(uint256[] calldata _altarLevel, uint256[] calldata _limits) external onlyOwner {
+    require(_altarLevel.length == _limits.length, "AlchemicaFacet: array mismatch");
+    for (uint256 i; i < _limits.length; i++) {
+      s.channelingLimits[_altarLevel[i]] = _limits[i];
     }
   }
 }

--- a/contracts/RealmDiamond/facets/AlchemicaFacet.sol
+++ b/contracts/RealmDiamond/facets/AlchemicaFacet.sol
@@ -307,11 +307,9 @@ contract AlchemicaFacet is Modifiers {
 
     require(block.timestamp - _lastChanneled >= 1 days, "AlchemicaFacet: Gotchi can't channel yet");
 
-    InstallationDiamondInterface.InstallationType memory altar = InstallationDiamondInterface(s.installationsDiamond).getInstallationType(
-      s.parcels[_realmId].altarId
-    );
+    uint256 altarLevel = InstallationDiamondInterface(s.installationsDiamond).getAltarLevel(s.parcels[_realmId].altarId);
 
-    require(block.timestamp > s.parcelChannelings[_realmId] + s.channelingLimits[altar.level], "AlchemicaFacet: Parcel can't channel yet");
+    require(block.timestamp > s.parcelChannelings[_realmId] + s.channelingLimits[altarLevel], "AlchemicaFacet: Parcel can't channel yet");
 
     //Use _lastChanneled to ensure that each signature hash is unique
     require(

--- a/contracts/TileDiamond/facets/TileFacet.sol
+++ b/contracts/TileDiamond/facets/TileFacet.sol
@@ -8,6 +8,7 @@ import {LibMeta} from "../../libraries/LibMeta.sol";
 import {LibERC1155Tile} from "../../libraries/LibERC1155Tile.sol";
 import {LibERC20} from "../../libraries/LibERC20.sol";
 import {LibTile} from "../../libraries/LibTile.sol";
+import {LibItems} from "../../libraries/LibItems.sol";
 import {IERC721} from "../../interfaces/IERC721.sol";
 import {RealmDiamond} from "../../interfaces/RealmDiamond.sol";
 import {IERC20} from "../../interfaces/IERC20.sol";
@@ -160,9 +161,8 @@ contract TileFacet is Modifiers {
       TileType memory tileType = s.tileTypes[_tileTypes[i]];
 
       //take the required alchemica
-      for (uint256 j = 0; j < tileType.alchemicaCost.length; j++) {
-        LibERC20.transferFrom(alchemicaAddresses[j], msg.sender, s.realmDiamond, tileType.alchemicaCost[j]);
-      }
+      LibItems._splitAlchemica(tileType.alchemicaCost, alchemicaAddresses);
+
       if (tileType.craftTime == 0) {
         LibERC1155Tile._safeMint(msg.sender, _tileTypes[i], 0);
       } else {
@@ -291,11 +291,15 @@ contract TileFacet is Modifiers {
   function setAddresses(
     address _aavegotchiDiamond,
     address _realmDiamond,
-    address _glmr
+    address _glmr,
+    address _pixelCraft,
+    address _aavegotchiDAO
   ) external onlyOwner {
     s.aavegotchiDiamond = _aavegotchiDiamond;
     s.realmDiamond = _realmDiamond;
     s.glmr = _glmr;
+    s.pixelCraft = _pixelCraft;
+    s.aavegotchiDAO = _aavegotchiDAO;
     emit AddressesUpdated(_aavegotchiDiamond, _realmDiamond, _glmr);
   }
 

--- a/contracts/interfaces/InstallationDiamond.sol
+++ b/contracts/interfaces/InstallationDiamond.sol
@@ -83,4 +83,6 @@ interface InstallationDiamondInterface {
   function spilloverRadiusOfId(uint256 _id) external view returns (uint256);
 
   function spilloverRateAndRadiusOfId(uint256 _id) external view returns (uint256, uint256);
+
+  function getAltarLevel(uint256 _altarId) external view returns (uint256 altarLevel_);
 }

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -76,7 +76,12 @@ struct AppStorage {
   bytes backendPubKey;
   address gameManager;
   mapping(uint256 => uint256) lastExitTime; //for aavegotchis exiting alchemica
+  // gotchiId => lastChanneledGotchi
   mapping(uint256 => uint256) gotchiChannelings;
+  // parcelId => lastChanneledParcel
+  mapping(uint256 => uint256) parcelChannelings;
+  // altarLevel => cooldown hours in seconds
+  mapping(uint256 => uint256) channelingLimits;
   address glmrAddress;
   address tileDiamond;
 }

--- a/contracts/libraries/AppStorageTile.sol
+++ b/contracts/libraries/AppStorageTile.sol
@@ -34,6 +34,8 @@ struct UpgradeQueue {
 struct TileAppStorage {
   address realmDiamond;
   address aavegotchiDiamond;
+  address pixelCraft;
+  address aavegotchiDAO;
   address glmr;
   address[] alchemicaAddresses;
   string baseUri;

--- a/contracts/libraries/LibAlchemica.sol
+++ b/contracts/libraries/LibAlchemica.sol
@@ -66,7 +66,6 @@ library LibAlchemica {
     if (installationType.installationType == 2) {
       require(s.parcels[_realmId].altarId == 0, "LibAlchemica: Cannot equip two altars");
       s.parcels[_realmId].altarId = _installationId;
-      s.parcelChannelings[_realmId] = block.timestamp - 24 hours;
     }
 
     // upgradeQueueBoost

--- a/contracts/libraries/LibAlchemica.sol
+++ b/contracts/libraries/LibAlchemica.sol
@@ -66,6 +66,7 @@ library LibAlchemica {
     if (installationType.installationType == 2) {
       require(s.parcels[_realmId].altarId == 0, "LibAlchemica: Cannot equip two altars");
       s.parcels[_realmId].altarId = _installationId;
+      s.parcelChannelings[_realmId] = block.timestamp - 24 hours;
     }
 
     // upgradeQueueBoost

--- a/contracts/libraries/LibInstallation.sol
+++ b/contracts/libraries/LibInstallation.sol
@@ -26,19 +26,4 @@ library LibInstallation {
     emit LibERC1155.TransferFromParent(s.realmDiamond, _realmId, _installationId, 1);
     LibERC1155._burn(s.realmDiamond, _installationId, 1);
   }
-
-  function _splitAlchemica(uint256[] memory _alchemicaCost, address[4] memory _alchemicaAddresses) internal {
-    InstallationAppStorage storage s = LibAppStorageInstallation.diamondStorage();
-    //take the required alchemica and split it
-    for (uint256 i = 0; i < _alchemicaCost.length; i++) {
-      uint256 greatPortal = (_alchemicaCost[i] * 40) / 100;
-      uint256 pixelCraftPart = (_alchemicaCost[i] * 40) / 100;
-      uint256 aavegotchiDAO = (_alchemicaCost[i] * 15) / 100;
-      uint256 burn = (_alchemicaCost[i] * 5) / 100;
-      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.realmDiamond, greatPortal);
-      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.pixelCraft, pixelCraftPart);
-      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.aavegotchiDAO, aavegotchiDAO);
-      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, address(0), burn);
-    }
-  }
 }

--- a/contracts/libraries/LibItems.sol
+++ b/contracts/libraries/LibItems.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import {LibERC20} from "../libraries/LibERC20.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {LibAppStorageInstallation, InstallationAppStorage} from "../libraries/AppStorageInstallation.sol";
+
+library LibItems {
+  function _splitAlchemica(uint256[] memory _alchemicaCost, address[4] memory _alchemicaAddresses) internal {
+    InstallationAppStorage storage s = LibAppStorageInstallation.diamondStorage();
+    //take the required alchemica and split it
+    for (uint256 i = 0; i < _alchemicaCost.length; i++) {
+      uint256 greatPortal = (_alchemicaCost[i] * 40) / 100;
+      uint256 pixelCraftPart = (_alchemicaCost[i] * 40) / 100;
+      uint256 aavegotchiDAO = (_alchemicaCost[i] * 15) / 100;
+      uint256 burn = (_alchemicaCost[i] * 5) / 100;
+      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.realmDiamond, greatPortal);
+      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.pixelCraft, pixelCraftPart);
+      LibERC20.transferFrom(_alchemicaAddresses[i], msg.sender, s.aavegotchiDAO, aavegotchiDAO);
+      IERC20(_alchemicaAddresses[i]).burnFrom(msg.sender, burn);
+    }
+  }
+}

--- a/contracts/test/AlchemicaToken.sol
+++ b/contracts/test/AlchemicaToken.sol
@@ -22,4 +22,9 @@ contract AlchemicaToken is ERC20Capped, Ownable {
   function mint(address _to, uint256 _value) public onlyOwner {
     _mint(_to, _value);
   }
+
+  function burnFrom(address account, uint256 amount) public virtual {
+    _spendAllowance(account, _msgSender(), amount);
+    _burn(account, amount);
+  }
 }

--- a/scripts/helperFunctions.ts
+++ b/scripts/helperFunctions.ts
@@ -66,6 +66,10 @@ export const kovanDiamondAddress = "0xa37D0c085121B6b7190A34514Ca28fC15Bb4dc22";
 export const maticDiamondAddress = "0x1D0360BaC7299C86Ec8E99d0c1C9A95FEfaF2a11";
 export const maticAavegotchiDiamondAddress =
   "0x86935F11C86623deC8a25696E1C19a8659CbF95d";
+export const aavegotchiDAOAddress =
+  "0xFFE6280ae4E864D9aF836B562359FD828EcE8020";
+//todo random address to be changed
+export const pixelCraftAddress = "0xB79Fad4cA981472442f53D16365fDf0305fFd8E9";
 
 export async function diamondOwner(address: string, ethers: any) {
   return await (await ethers.getContractAt("OwnershipFacet", address)).owner();

--- a/scripts/realm/realmHelpers.ts
+++ b/scripts/realm/realmHelpers.ts
@@ -114,7 +114,7 @@ export function testInstallations() {
       upgradeQueueBoost: 0,
       craftTime: 10000,
       deprecated: false,
-      nextLevelId: 0,
+      nextLevelId: 7,
       prerequisites: [],
       name: "Altar level 1",
     })
@@ -174,7 +174,7 @@ export function testInstallations() {
       upgradeQueueBoost: 0,
       craftTime: 10000,
       deprecated: false,
-      nextLevelId: 5,
+      nextLevelId: 7,
       prerequisites: [],
       name: "Altar level 1",
     })
@@ -217,6 +217,26 @@ export function testInstallations() {
       nextLevelId: 0,
       prerequisites: [],
       name: "BuildQueue level 1",
+    })
+  );
+  installations.push(
+    outputInstallation({
+      installationType: 2,
+      level: 2,
+      width: 2,
+      height: 2,
+      alchemicaType: 0,
+      alchemicaCost: [100, 20, 0, 30],
+      harvestRate: 2,
+      capacity: 0,
+      spillRadius: 0,
+      spillRate: 20,
+      upgradeQueueBoost: 0,
+      craftTime: 10000,
+      deprecated: false,
+      nextLevelId: 0,
+      prerequisites: [],
+      name: "Altar level 2",
     })
   );
 

--- a/scripts/realm/realmHelpers.ts
+++ b/scripts/realm/realmHelpers.ts
@@ -1,5 +1,5 @@
 import { BigNumber, ethers } from "ethers";
-import { Network, NetworkConfig } from "hardhat/types";
+import { Network } from "hardhat/types";
 import {
   AlchemicaFacet,
   AlchemicaToken,
@@ -22,6 +22,8 @@ import {
 import {
   maticAavegotchiDiamondAddress,
   maticDiamondAddress,
+  pixelCraftAddress,
+  aavegotchiDAOAddress,
 } from "../helperFunctions";
 import { deployDiamond } from "../installation/deploy";
 import { impersonate } from "../installation/helperFunctions";
@@ -500,12 +502,16 @@ export async function beforeTest(
   await installationAdminFacet.setAddresses(
     maticAavegotchiDiamondAddress,
     maticDiamondAddress,
-    glmr.address
+    glmr.address,
+    pixelCraftAddress,
+    aavegotchiDAOAddress
   );
   await tileDiamond.setAddresses(
     maticAavegotchiDiamondAddress,
     realmDiamondAddress,
-    glmr.address
+    glmr.address,
+    pixelCraftAddress,
+    aavegotchiDAOAddress
   );
 
   return {

--- a/scripts/realm/upgrades/upgrade-harvesting.ts
+++ b/scripts/realm/upgrades/upgrade-harvesting.ts
@@ -46,6 +46,8 @@ export async function upgrade(
         "function getRoundBaseAlchemica(uint256 _realmId, uint256 _roundId) external view returns (uint256[] memory)",
         "function getLastChanneled(uint256 _gotchiId) public view returns (uint256)",
         "function getAlchemicaAddresses() external view returns (address[4] memory)",
+        "function setChannelingLimits(uint256[] calldata _altarLevel, uint256[] calldata _limits) external",
+        "function batchTransferAlchemica(address[] calldata _targets, uint256[4][] calldata _amounts) external",
       ],
       removeSelectors: [],
     },

--- a/test/tile/tileTest.ts
+++ b/test/tile/tileTest.ts
@@ -1,7 +1,9 @@
 import {
+  aavegotchiDAOAddress,
   impersonate,
   maticDiamondAddress,
   mineBlocks,
+  pixelCraftAddress,
 } from "../../scripts/helperFunctions";
 import { ethers, network } from "hardhat";
 import { expect } from "chai";
@@ -126,16 +128,36 @@ describe("Testing Tiles", async function () {
     await g.fomo.approve(g.tileAddress, ethers.utils.parseUnits("1000000000"));
     await g.alpha.approve(g.tileAddress, ethers.utils.parseUnits("1000000000"));
     await g.kek.approve(g.tileAddress, ethers.utils.parseUnits("1000000000"));
-    let fudPreCraft = await g.fud.balanceOf(maticDiamondAddress);
-    let kekPreCraft = await g.kek.balanceOf(maticDiamondAddress);
+    let fudPreCraftPortal = await g.fud.balanceOf(maticDiamondAddress);
+    let kekPreCraftPortal = await g.kek.balanceOf(maticDiamondAddress);
+    let fudPreCraftPixelCraft = await g.fud.balanceOf(pixelCraftAddress);
+    let kekPreCraftPixelCraft = await g.kek.balanceOf(pixelCraftAddress);
+    let fudPreCraftDAO = await g.fud.balanceOf(aavegotchiDAOAddress);
+    let kekPreCraftDAO = await g.kek.balanceOf(aavegotchiDAOAddress);
     await g.tileDiamond.craftTiles([1, 2, 2, 3]);
-    let fudAfterCraft = await g.fud.balanceOf(maticDiamondAddress);
-    let kekAfterCraft = await g.kek.balanceOf(maticDiamondAddress);
-    expect(Number(ethers.utils.formatUnits(fudAfterCraft))).to.above(
-      Number(ethers.utils.formatUnits(fudPreCraft))
+    let fudAfterCraftPortal = await g.fud.balanceOf(maticDiamondAddress);
+    let kekAfterCraftPortal = await g.kek.balanceOf(maticDiamondAddress);
+    let fudAfterCraftPixelCraft = await g.fud.balanceOf(pixelCraftAddress);
+    let kekAfterCraftPixelCraft = await g.kek.balanceOf(pixelCraftAddress);
+    let fudAfterCraftDAO = await g.fud.balanceOf(aavegotchiDAOAddress);
+    let kekAfterCraftDAO = await g.kek.balanceOf(aavegotchiDAOAddress);
+    expect(Number(ethers.utils.formatUnits(fudAfterCraftPortal))).to.above(
+      Number(ethers.utils.formatUnits(fudPreCraftPortal))
     );
-    expect(Number(ethers.utils.formatUnits(kekAfterCraft))).to.above(
-      Number(ethers.utils.formatUnits(kekPreCraft))
+    expect(Number(ethers.utils.formatUnits(kekAfterCraftPortal))).to.above(
+      Number(ethers.utils.formatUnits(kekPreCraftPortal))
+    );
+    expect(Number(ethers.utils.formatUnits(fudAfterCraftPixelCraft))).to.above(
+      Number(ethers.utils.formatUnits(fudPreCraftPixelCraft))
+    );
+    expect(Number(ethers.utils.formatUnits(kekAfterCraftPixelCraft))).to.above(
+      Number(ethers.utils.formatUnits(kekPreCraftPixelCraft))
+    );
+    expect(Number(ethers.utils.formatUnits(fudAfterCraftDAO))).to.above(
+      Number(ethers.utils.formatUnits(fudPreCraftDAO))
+    );
+    expect(Number(ethers.utils.formatUnits(kekAfterCraftDAO))).to.above(
+      Number(ethers.utils.formatUnits(kekPreCraftDAO))
     );
     await expect(g.tileDiamond.claimTiles([0])).to.be.revertedWith(
       "TileFacet: tile not ready"


### PR DESCRIPTION
- limit channeling of alchemica from a parcel from different gotchis
- the limits are stored in a mapping altarLevel => cooldown hours in seconds
- the limits can be set through the onlyOwner function in AlchemicaFacet setChannelingLimits